### PR TITLE
fix(deps): Update stack definition member versions

### DIFF
--- a/stack_definition.json
+++ b/stack_definition.json
@@ -315,6 +315,10 @@
           "value": "ref:../../members/3 - Event Notifications/outputs/crn"
         },
         {
+          "name": "existing_event_notification_instance_crn",
+          "value": "ref:../../members/3 - Event Notifications/outputs/crn"
+        },
+        {
           "name": "existing_secrets_manager_crn",
           "value": "ref:../../inputs/existing_secrets_manager_crn"
         },
@@ -325,6 +329,10 @@
         {
           "name": "iam_engine_enabled",
           "value": "ref:../../inputs/secret_manager_iam_engine_enabled"
+        },
+        {
+          "name": "enable_event_notification",
+          "value": true
         }
       ],
       "name": "4b - Secrets Manager",

--- a/stack_definition.json
+++ b/stack_definition.json
@@ -79,13 +79,13 @@
       "default": "security-compliance-center-standard-plan",
       "custom_config": {}
     },
-	{
-		"name": "secret_manager_iam_engine_enabled",
-		"required": false,
-		"type": "boolean",
-		"hidden": false,
-		"default": false
-	}
+    {
+      "name": "secret_manager_iam_engine_enabled",
+      "required": false,
+      "type": "boolean",
+      "hidden": false,
+      "default": false
+    }
   ],
   "members": [
     {
@@ -112,7 +112,7 @@
         }
       ],
       "name": "1a - Key management",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.650ff7c9-5a41-4d32-a0db-6720ff56a016-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.206bfa3d-3bbe-435e-adb9-dd244fdaad86-global"
     },
     {
       "inputs": [
@@ -134,7 +134,7 @@
         }
       ],
       "name": "1b - Object storage",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.75709d42-41a3-41ca-8f45-807652f0d1f7-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.1db2434c-c55f-4a5e-9814-1b39f9580b86-global"
     },
     {
       "inputs": [
@@ -176,7 +176,7 @@
         }
       ],
       "name": "2 - Observability",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.9559b390-b310-4373-a61d-c4add658c3cf-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.9a4b4855-07a5-43a0-af1d-ef44e091821c-global"
     },
     {
       "inputs": [
@@ -226,7 +226,7 @@
         }
       ],
       "name": "3 - Event Notifications",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.3910e11e-c90b-48b0-b271-ec5d5049ad84-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.ee7b0d6c-3603-40fb-953b-4bdbd43c3cbe-global"
     },
     {
       "inputs": [
@@ -286,7 +286,7 @@
         }
       ],
       "name": "4a - Security and Compliance Center",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.1ac9df0e-d3d5-4ed8-abfc-043578670dbb-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c689955e-d4ad-4f9e-8bdc-c8929dd5991a-global"
     },
     {
       "inputs": [
@@ -322,13 +322,13 @@
           "name": "service_plan",
           "value": "ref:../../inputs/sm_service_plan"
         },
-		{
-			"name": "iam_engine_enabled",
-			"value": "ref:../../inputs/secret_manager_iam_engine_enabled"
-		}
+        {
+          "name": "iam_engine_enabled",
+          "value": "ref:../../inputs/secret_manager_iam_engine_enabled"
+        }
       ],
       "name": "4b - Secrets Manager",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e806bb05-dfb9-40a8-99bf-1b9272cf8d82-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.f98df044-b1c7-4f38-86db-6438e76a35bf-global"
     }
   ],
   "outputs": [


### PR DESCRIPTION
```
[subprocess - update_stack_definition.py] INFO: Updating 1a - Key management
[subprocess - update_stack_definition.py] INFO: current version: v4.15.0
[subprocess - update_stack_definition.py] INFO: latest version: v4.15.9
[subprocess - update_stack_definition.py] INFO: latest version locator: 7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.206bfa3d-3bbe-435e-adb9-dd244fdaad86-global
[subprocess - update_stack_definition.py] INFO: Updating 1a - Key management to version v4.15.9
```
^^ summary release notes:
- IBM provider bumped to `1.68.1`
- Dependant modules versions updated

```
[subprocess - update_stack_definition.py] INFO: Updating 1b - Object storage
[subprocess - update_stack_definition.py] INFO: current version: v8.8.4
[subprocess - update_stack_definition.py] INFO: latest version: v8.11.3
[subprocess - update_stack_definition.py] INFO: latest version locator: 7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.1db2434c-c55f-4a5e-9814-1b39f9580b86-global
[subprocess - update_stack_definition.py] INFO: Updating 1b - Object storage to version v8.11.3
```
^^ summary release notes:
- IBM provider bumped to `1.68.1`
- Dependant modules versions updated

```
[subprocess - update_stack_definition.py] INFO: Updating 2 - Observability
[subprocess - update_stack_definition.py] INFO: current version: v1.11.0
[subprocess - update_stack_definition.py] INFO: latest version: v1.12.3
[subprocess - update_stack_definition.py] INFO: latest version locator: 7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.9a4b4855-07a5-43a0-af1d-ef44e091821c-global
[subprocess - update_stack_definition.py] INFO: Updating 2 - Observability to version v1.12.3
```
^^ summary release notes:
- IBM provider bumped to `1.68.1`
- Dependant modules versions updated
```
[subprocess - update_stack_definition.py] INFO: Updating 3 - Event Notifications
[subprocess - update_stack_definition.py] INFO: current version: v1.9.0
[subprocess - update_stack_definition.py] INFO: latest version: v1.10.6
[subprocess - update_stack_definition.py] INFO: latest version locator: 7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.ee7b0d6c-3603-40fb-953b-4bdbd43c3cbe-global
[subprocess - update_stack_definition.py] INFO: Updating 3 - Event Notifications to version v1.10.6
```
^^ summary release notes:
- IBM provider bumped to `1.68.1`
- Dependant modules versions updated
```
[subprocess - update_stack_definition.py] INFO: Updating 4a - Security and Compliance Center
[subprocess - update_stack_definition.py] INFO: current version: v1.15.0
[subprocess - update_stack_definition.py] INFO: latest version: v1.17.2
[subprocess - update_stack_definition.py] INFO: latest version locator: 7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c689955e-d4ad-4f9e-8bdc-c8929dd5991a-global
[subprocess - update_stack_definition.py] INFO: Updating 4a - Security and Compliance Center to version v1.17.2
```
^^ summary release notes:
- IBM provider bumped to `1.69.0` which fixes an issue that was being seen when trying to create an SCC attachment for certain profiles (more info: https://github.com/IBM-Cloud/terraform-provider-ibm/issues/5586)
- Dependant modules versions updated

```
[subprocess - update_stack_definition.py] INFO: Updating 4b - Secrets Manager
[subprocess - update_stack_definition.py] INFO: current version: v1.17.1
[subprocess - update_stack_definition.py] INFO: latest version: v1.17.10
[subprocess - update_stack_definition.py] INFO: latest version locator: 7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.f98df044-b1c7-4f38-86db-6438e76a35bf-global
[subprocess - update_stack_definition.py] INFO: Updating 4b - Secrets Manager to version v1.17.10
[subprocess - update_stack_definition.py] 
[subprocess - update_stack_definition.py] INFO: Stack definition updated: /mnt/operations/stack-update/stack-updater/stack-ibm-core-security-services/stack_definition.json
```

^^ summary release notes:
- IBM provider bumped to `1.68.1`
- Dependant modules versions updated