### PR TITLE
v2.0.0 release

### DIFF
--- a/stack_definition.json
+++ b/stack_definition.json
@@ -268,7 +268,7 @@
         },
         {
           "name": "skip_cos_kms_auth_policy",
-          "value": true
+          "value": false
         },
         {
           "name": "existing_en_crn",

--- a/stack_definition.json
+++ b/stack_definition.json
@@ -112,7 +112,7 @@
         }
       ],
       "name": "1a - Key management",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.7f57ef48-2bb2-4641-8f6e-db27a7eacc38-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.3b5c0ef5-6438-4e7b-8a88-88636bc590c6-global"
     },
     {
       "inputs": [
@@ -134,7 +134,7 @@
         }
       ],
       "name": "1b - Object storage",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.54ae4d96-9c0d-430c-a5d1-51785ffe4cd0-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.f039fa0e-24f7-4c12-a617-1dee12997859-global"
     },
     {
       "inputs": [
@@ -175,16 +175,12 @@
           "value": "ref:../../inputs/enable_platform_logs_metrics"
         },
         {
-          "name": "log_analysis_enable_archive",
-          "value": false
-        },
-        {
-          "name": "log_analysis_provision",
-          "value": true
+          "name": "existing_en_instance_crn",
+          "value": "ref:../../members/3 - Event Notifications/outputs/crn"
         }
       ],
       "name": "2 - Observability",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.2515f999-c6c3-4fa3-81eb-03b26d019bb2-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.489dde17-2578-499a-8c3a-781b5248a3da-global"
     },
     {
       "inputs": [
@@ -227,14 +223,10 @@
         {
           "name": "prefix",
           "value": "ref:../../inputs/prefix"
-        },
-        {
-          "name": "existing_monitoring_crn",
-          "value": "ref:../../members/2 - Observability/outputs/cloud_monitoring_crn"
         }
       ],
       "name": "3 - Event Notifications",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.b5b38d6e-441e-4915-ac00-9a75b442a9f0-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.dfffe742-c7a1-452e-90b1-3080f1f57f78-global"
     },
     {
       "inputs": [
@@ -298,7 +290,7 @@
         }
       ],
       "name": "4a - Security and Compliance Center",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.b27fc8c7-f6ec-4f98-890d-4f7ccfd37aaf-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.29b5ef2b-a3c1-4798-9595-ed1263945f82-global"
     },
     {
       "inputs": [
@@ -344,7 +336,7 @@
         }
       ],
       "name": "4b - Secrets Manager",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.03587d2d-38bd-42c3-983b-72469702e038-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e314e905-ca89-4947-aa94-23d270516f0e-global"
     }
   ],
   "outputs": [

--- a/stack_definition.json
+++ b/stack_definition.json
@@ -223,6 +223,10 @@
         {
           "name": "prefix",
           "value": "ref:../../inputs/prefix"
+        },
+        {
+          "name": "existing_monitoring_crn",
+          "value": "__NULL__"
         }
       ],
       "name": "3 - Event Notifications",

--- a/stack_definition.json
+++ b/stack_definition.json
@@ -194,7 +194,7 @@
         },
         {
           "name": "skip_cos_kms_auth_policy",
-          "value": true
+          "value": false
         },
         {
           "name": "kms_endpoint_url",


### PR DESCRIPTION
### Description

Update all members to the latest version versions. This update will remove logdna, so marking as a breaking change (v2.0.0)

| Stack | Change |
|---|---|
| 1a - Key management | `v4.15.13` --> `v4.16.7` |
| 1b - Object storage | `v8.11.14` --> `v8.14.0` |
| 2 - Observability | `v1.19.0` --> `v2.1.0` |
| 3 - Event Notifications | `v1.10.19` --> `v1.14.0` |
| 4a - Security and Compliance Center | `v1.20.2` --> `v1.21.0` |
| 4b - Secrets Manager | `v1.18.6` --> `v1.18.12` |

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [x] Major release (`X.x.x`)

##### Release notes content

- 1a - Key management - `v4.15.13` --> `v4.16.7`
    - dependency updates
- 1b - Object storage - `v8.11.14` --> `v8.14.0`
    - dependency updates
    - updated the KMS auth policy so its scoped to the exact KMS Key. NOTE: This will delete and re-create any existing auth policy, however it will create before delete so there will be no disruption to every day services.
- 2 - Observability - `v1.19.0` --> `v2.1.0`
    - dependency updates
    - removed Log Analysis support - this will delete the Log Analysis instance and resource key on upgrade.
    - updated the KMS auth policy so its scoped to the exact KMS Key. NOTE: This will delete and re-create any existing auth policy, however it will create before delete so there will be no disruption to every day services.
    - Enabled Event Notifications integration for Cloud Logs
- 3 - Event Notifications - `v1.10.19` --> `v1.14.0`
    - updated the KMS auth policy so its scoped to the exact KMS Key. NOTE: This will delete and re-create any existing auth policy, however it will create before delete so there will be no disruption to every day services.
    - updated the configuration in the DA that is used to stored failed events in a COS bucket to now use the direct COS endpoint by default (previously it was using the public endpoint). This change is done as an update in place.
    - Updated the configuration of the COS bucket so the Monitoring instance is no longer explicitly passed to it. The bucket metrics will still be monitored, however metrics will be sent to the instance associated to the container's location unless otherwise specified in the Metrics Router service configuration. This change is done as an update in place.
    - An update in place will be done on the KMS key rings since the `force_delete` option has been deprecated by the service. This has no impact to any services as the value is not being used by the backend.
- 4a - Security and Compliance Center - `v1.20.2` --> `v1.21.0`
    - updated the KMS auth policy so its scoped to the exact KMS Key. NOTE: This will delete and re-create any existing auth policy, however it will create before delete so there will be no disruption to every day services.
- 4b - Secrets Manager - `v1.18.6` --> `v1.18.12`
    - An update in place will be done on the KMS key ring since the `force_delete` option has been deprecated by the service. This has no impact to any services as the value is not being used by the backend.
    

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
