### PR TITLE
fix(deps): Update stack definition member versions

### DIFF
--- a/stack_definition.json
+++ b/stack_definition.json
@@ -157,7 +157,7 @@
         }
       ],
       "name": "1a - Key management",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.fba8aa38-b3d8-4c5e-af43-e125f02e5f15-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.210731e1-812e-4253-a5c3-ab485285aed4-global"
     },
     {
       "inputs": [
@@ -171,7 +171,7 @@
         }
       ],
       "name": "1b - Object storage",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.a188a45a-0cc1-4f5b-86e5-d126b6097eb2-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.dabe69f5-8e39-4c44-b692-9fc458bb02ea-global"
     },
     {
       "inputs": [
@@ -197,7 +197,7 @@
         }
       ],
       "name": "1c - Cloud Monitoring",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.50ebf77c-a703-404a-b803-1e5f11612bc0-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c925f8db-486d-47dd-a2f5-75a822c32c42-global"
     },
     {
       "inputs": [
@@ -247,7 +247,7 @@
         }
       ],
       "name": "2 - Event Notifications",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c087bb90-4cba-4569-8a5a-8cdf70cd0f24-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.8accba96-48f2-4641-b8e1-65adc766c8d4-global"
     },
     {
       "inputs": [
@@ -293,7 +293,7 @@
         }
       ],
       "name": "3a - Cloud Logs for logging",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.d9c20c4d-dc28-44ff-bc71-5ce113e784a2-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.7c35fae5-48ef-470b-927a-8c5978b3f8b4-global"
     },
     {
       "inputs": [
@@ -351,7 +351,7 @@
         }
       ],
       "name": "3b - Cloud Logs for activity tracking",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.d9c20c4d-dc28-44ff-bc71-5ce113e784a2-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.7c35fae5-48ef-470b-927a-8c5978b3f8b4-global"
     },
     {
       "inputs": [
@@ -417,7 +417,7 @@
         }
       ],
       "name": "3c - App Configuration",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.0da1eb31-bbea-483d-a600-2ea105ed5018-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.2c072ac6-0941-4c32-a38b-d910c0eff20b-global"
     },
     {
       "inputs": [
@@ -463,7 +463,7 @@
         }
       ],
       "name": "3d - Secrets Manager",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.86f1075b-de70-46bd-a6cd-aadfdda7e1da-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.77243305-ade8-40d7-9446-6a948b232e75-global"
     },
     {
       "inputs": [
@@ -497,7 +497,7 @@
         }
       ],
       "name": "4a - Security and Compliance Center Workload Protection",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.41d84a24-fc56-4094-9f73-265ddc7ab63b-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.05e542b1-f45e-4e01-a4cb-a829d60616f9-global"
     },
     {
       "inputs": [
@@ -535,7 +535,7 @@
         }
       ],
       "name": "4b - Activity Tracker Event Routing",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.247af203-d8ce-43bd-b8dc-f5375d94987d-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.f4039829-46af-4641-99b7-3841d48060f1-global"
     }
   ],
   "outputs": [


### PR DESCRIPTION
Update stack definition member versions

| Stack | Change |
|---|---|
| 1a - Key management | `v5.5.29` --> `v5.5.36` |
| 1b - Object storage | `v10.14.1` --> `v10.14.10` |
| 1c - Cloud Monitoring | `v1.13.5` --> `v1.14.5` |
| 2 - Event Notifications | `v2.11.16` --> `v2.11.29` |
| 3a - Cloud Logs for logging | `v1.11.4` --> `v1.12.8` |
| 3b - Cloud Logs for activity tracking | `v1.11.4` --> `v1.12.8` |
| 3c - App Configuration | `v1.15.7` --> `v1.16.1` |
| 3d - Secrets Manager | `v2.13.3` --> `v2.13.9` |
| 4a - Security and Compliance Center Workload Protection | `v1.17.4` --> `v1.18.2` |
| 4b - Activity Tracker Event Routing | `v1.6.13` --> `v1.7.1` |
