### PR TITLE
fix(deps): Update stack definition member versions

### DIFF
--- a/stack_definition.json
+++ b/stack_definition.json
@@ -171,7 +171,7 @@
         }
       ],
       "name": "1b - Object storage",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.0e1b5ac9-0b83-4307-802c-0c93b054709f-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.5d20e1cf-b4fd-4c2a-a50a-f2608cdd72ef-global"
     },
     {
       "inputs": [
@@ -197,7 +197,7 @@
         }
       ],
       "name": "1c - Cloud Monitoring",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.ac367d71-f094-4b1b-a1dc-e98fe3fcdaf8-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.83cd7e94-a8e6-426e-8341-198909924f27-global"
     },
     {
       "inputs": [
@@ -247,7 +247,7 @@
         }
       ],
       "name": "2 - Event Notifications",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.ba2ab63b-31c5-4a23-93e3-ea2a2b34b5f4-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.efa99cfb-c40d-456b-aad9-4aad12b2422e-global"
     },
     {
       "inputs": [
@@ -293,7 +293,7 @@
         }
       ],
       "name": "3a - Cloud Logs for logging",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e80a0fd0-1d80-4c7e-a19e-72844cc98e35-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.bd760abb-98b1-4ca5-9661-6937cb4cee79-global"
     },
     {
       "inputs": [
@@ -351,7 +351,7 @@
         }
       ],
       "name": "3b - Cloud Logs for activity tracking",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e80a0fd0-1d80-4c7e-a19e-72844cc98e35-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.bd760abb-98b1-4ca5-9661-6937cb4cee79-global"
     },
     {
       "inputs": [
@@ -417,7 +417,7 @@
         }
       ],
       "name": "3c - App Configuration",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.ba381d2a-2ed0-4ff3-85d5-ca194322ed5b-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.f3e4d54d-e1dd-474f-9074-10b66c2a31f8-global"
     },
     {
       "inputs": [
@@ -463,7 +463,7 @@
         }
       ],
       "name": "3d - Secrets Manager",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e244cf2f-c4c6-4aa4-88c3-36546b091818-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.48d2d267-3865-4f27-8e50-30e1ec52af18-global"
     },
     {
       "inputs": [
@@ -497,7 +497,7 @@
         }
       ],
       "name": "4a - Security and Compliance Center Workload Protection",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.d5d5a70d-c4e9-4e3f-9b11-cb460da0c88e-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.0f0117b9-5b92-4e6f-9e2f-e85075102230-global"
     },
     {
       "inputs": [
@@ -535,7 +535,7 @@
         }
       ],
       "name": "4b - Activity Tracker Event Routing",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.3610dcb3-1a00-40e4-9843-0a274fe596e6-global"
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.b9febd28-8597-4f10-85ae-3c0bdab52665-global"
     }
   ],
   "outputs": [


### PR DESCRIPTION
Update stack definition member versions

| Stack | Change |
|---|---|
| 1b - Object storage | `v10.16.5` --> `v10.17.5` |
| 1c - Cloud Monitoring | `v1.15.8` --> `v1.15.11` |
| 2 - Event Notifications | `v2.12.14` --> `v2.12.25` |
| 3a - Cloud Logs for logging | `v1.13.12` --> `v1.13.21` |
| 3b - Cloud Logs for activity tracking | `v1.13.12` --> `v1.13.21` |
| 3c - App Configuration | `v1.18.8` --> `v1.18.11` |
| 3d - Secrets Manager | `v2.15.7` --> `v2.15.12` |
| 4a - Security and Compliance Center Workload Protection | `v1.19.5` --> `v1.21.0` |
| 4b - Activity Tracker Event Routing | `v1.8.9` --> `v1.8.17` |
